### PR TITLE
Fix / improve non-CRAN dependencies via Remotes

### DIFF
--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -233,6 +233,4 @@ In the beginning of the `ui` function, we also need to add a call to `shiny::add
 
 ### non-CRAN dependencies
 
-Deploying a packaged shiny application which uses non-CRAN sources like Github can also cause issues. It is recommended to list these dependencies under [`Remotes:`](https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html) instead of e.g. `Imports:`, to make sure package versioning tools like `renv` notice the difference.
-
-
+Deploying a packaged shiny application which uses non-CRAN package sources like Github requires additional information in the `DESCRIPTION` file. Namely, the repository details of such dependencies must be included in a [`Remotes:`](https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html) field, to allow tools like `renv` or `remotes` to know where the packages should be retrieved from.

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -233,4 +233,4 @@ In the beginning of the `ui` function, we also need to add a call to `shiny::add
 
 ### non-CRAN dependencies
 
-Deploying a packaged shiny application which uses non-CRAN package sources like Github requires additional information in the `DESCRIPTION` file. Namely, the repository details of such dependencies must be included in a [`Remotes:`](https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html) field, to allow tools like `renv` or `remotes` to know where the packages should be retrieved from.
+Deploying a packaged shiny application which uses non-CRAN package sources like Github requires additional information in the `DESCRIPTION` file. Namely, the repository details of such dependencies must be included in a [`Remotes:`](https://cran.r-project.org/web/packages/devtools/vignettes/dependencies.html) field, so that tools like `renv` or `remotes` know where the packages should be retrieved from.


### PR DESCRIPTION
* Fix the inaccurate "`Remotes:` instead of  e.g. `Imports:`" and be more precise about the meaning of the field, i.e. specify the repository info for non-CRAN dependencies.
* Also be more explicit about this being actually required to resolve such dependencies in general.