### PR TITLE
add github repo icon

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -2,10 +2,14 @@
 title: "Technical Guidelines"
 author: "Mirai Solutions"
 date: "`r Sys.time()`"
+github-repo: "miraisolutions/techguides"
 site: bookdown::bookdown_site
-output: 
+output:
   bookdown::gitbook:
     split_by: section
+    config:
+      sharing:
+        github: yes
 ---
 
 # Introduction {-}


### PR DESCRIPTION
I updated index.Rmd to include the GitHub repo icon according to the documentation in https://bookdown.org/yihui/bookdown/html.html#gitbook-style

The file _main.rds was also changed. I did not commit that yet as it seems to be automatically generated by bookdown.
It looks like we should delete this file from version control and put it into .gitignore. What is your opinion on this @riccardoporreca ?