### PR TITLE
Remove explicit exclusion of renv since it is not required anymore

### DIFF
--- a/shiny-ci-cd/deploy/deploy-shinyapps.R
+++ b/shiny-ci-cd/deploy/deploy-shinyapps.R
@@ -5,8 +5,4 @@ rsconnect::setAccountInfo(
   Sys.getenv("SHINYAPPS_TOKEN"),
   Sys.getenv("SHINYAPPS_SECRET")
 )
-rsconnect::deployApp(
-  appName = "ShinyCICD",
-  # exclude hidden files and renv directory (if present)
-  appFiles = setdiff(list.files(), "renv")
-)
+rsconnect::deployApp(appName = "ShinyCICD")


### PR DESCRIPTION
There are some new htmlproofer errors. One of them looks like a false positive to me, but the other two links seem to have disappeared from rocker-project.org completely.