### PR TITLE
Update Actions status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # techguides
 
 <!-- badges: start -->
-[![CI-CD](https://github.com/miraisolutions/techguides/workflows/CI-CD/badge.svg)](https://github.com/miraisolutions/techguides/actions)
+[![CI-CD](https://github.com/miraisolutions/techguides/actions/workflows/site.yaml/badge.svg)](https://github.com/miraisolutions/techguides/actions/workflows/site.yaml)
 <!-- badges: end -->
 
 `techguides` is an open source project to collect technical guidelines and best practices. At [Mirai Solutions](https://mirai-solutions.ch) we envision `techguides` as a dynamic and evolving project where we can share with the community some of the experience we gather in our daily work.


### PR DESCRIPTION
* The existing legacy inclusion code and URLs are replaced based on the current "Create status badge" in GitHub.