### PR TITLE
Feature/41 renv rsconnect updates

### DIFF
--- a/renv.Rmd
+++ b/renv.Rmd
@@ -34,28 +34,31 @@ renv::init(
 
 This ensures that the dependencies of the package, as listed in the `DESCRIPTION` file are used for initializing the virtual environment. 
 
-Note: `renv` tracks and installs only the packages explicitly mentioned in the `DESCRIPTION` file. This means that only the dependencies used by the package are installed. Packages needed for development, such as `devtools`, should be be installed for the specific project via `install.packages()` or `renv::install()`.
+Note: with `snapshot.type = "explicit"` `renv` tracks and installs only the packages *explicitly* mentioned in the `DESCRIPTION` file. This means that only the dependencies used by the package are installed. Packages needed for development, such as `devtools`, should be be installed for the specific project via `install.packages()` or `renv::install()`.   
+`snapshot.type = "explicit"`,  (the default), uses all packages captured by `renv::dependencies()`.
 
 The `renv` initialization causes:
 
-- the creation of a new `renv.lock` file where the R version and the list of used packages with their version are tracked;
+- the creation of a new `renv.lock` file where the R version and the list of used packages with their version are tracked (if `bare = FALSE`);
+- the set-up of project infrastructure including the project library;
+- the execution of the activation script on project launch via `.Rprofile` that ensures renv will be used in all future sessions;
 - the creation of a new `renv` folder containing:
-    - a setting file `settings.dcf`,
-    - a script `activate.R` to activate the project-specific virtual environment,
-    - the project-specific `library` of installed packages;
-- the execution of the activation script on project launch via `.Rprofile`;
+    - a setting file `settings.jsn`,
+    - a script `activate.R` to activate the project-specific virtual environment;
 - an update of the `.Rbuildignore` because the `renv`-specific files are not part of the R package infrastructure;
 - an update of the `.gitignore` to exclude the `renv` library from version control, as it can be simply restored via `renv::restore()`.
 
-Having all the `renv` infrastructure committed under version control ensures that the same `renv` setup is available to anyone working on the same project (via `renv::restore()`).
+Having all the `renv` infrastructure committed under version control ensures that the same `renv` set-up is available to anyone working on the same project (via `renv::restore()`).
+
+By default `renv` will use the repository from **Posit Public Package Manager** (*PPM*) CRAN mirror for package installation. 
 
 ### Control packages version
 
-As a note, if the `DESCRIPTION` file does not request a specific package version, the `renv` initialization will pick the version currently available in the user library when the snapshot of the packages was created. However, it is advisable to have a stricter control over the version of the packages used in a project. To do so, one can set the option to install dependencies from a specific MRAN repo, therefore fixing the version for all available packages.
+As a note, if the `DESCRIPTION` file does not request a specific package version, the `renv` initialization will pick the version currently available in the user library when the snapshot of the packages was created. However, it is advisable to have a stricter control over the version of the packages used in a project. To do so, one can set the option to install dependencies from a specific *PPM* repo, therefore fixing the version for all available packages.
 
 ```{r , echo = TRUE, eval = FALSE}
-# Install all dependencies from a specific MRAN date repo
-options(repos = "https://mran.microsoft.com/snapshot/2020-11-15")
+# Install all dependencies from a specific PPM date repo
+options(repos = "https://packagemanager.rstudio.com/cran/2023-01-02")
 ```
 
 One can then install the dependencies of a package via:
@@ -72,26 +75,50 @@ To create a snapshot of the package dependencies and update the `renv.lock` file
 # Create a snapshot to track dependencies in the lockfile
 renv::snapshot()
 ```
+To include development dependencies, i.e. listed in `Suggests` of the `DESCRIPTION` file:
+
+```{r , echo = TRUE, eval = FALSE}
+# Create a snapshot to track all dependencies, including Suggested, in the lockfile
+renv::snapshot(dev = TRUE)
+```
+
+Similarly to fixing the date of a snapshot repo, we can also **check out** and retrieve the latest-available packages from a snapshot.
+```{r , echo = TRUE, eval = FALSE}
+# check out packages from PPM using the date '2023-01-02'
+renv::checkout(date = "2023-01-02")
+# or
+renv::checkout(repos = "https://packagemanager.rstudio.com/cran/2023-01-02")
+# see "actions" argument for different snapshot behaviours.
+```
+
+The same can be done for a single package.
+```{r , echo = TRUE, eval = FALSE}
+# only check out a subset of packages (and their recursive dependencies)
+renv::checkout(packages = "dplyr", date = "2023-01-02")
+```
 
 ## Caching the packages' versions
 
-`renv` caches the packages' versions. If you have installed the same package version in a different project, you should have it already cached and available. By running:
+`renv` caches the packages' versions. If you have installed the same package version in a different project, you should have it already cached and available.   
+By running:
 
 ```{r, echo =  TRUE , eval = FALSE}
 renv::status()
 ```
 
-One can check if packages versions are out of sync and via 
+one can check if packages versions are out of sync, and follow the indications in the "Missing packages" of `?renv::status` if mismatches are found.
+
+Instead, via 
 
 ```{r, echo =  TRUE , eval = FALSE}
 renv::restore()
 ```
 
-It is possible to restore the versions as listed in the `renv.lock` file.
+it is possible to restore the versions as listed in the `renv.lock` file.
 
 ## Removing the `renv` setup from a project
 
-If you would like to remove the `renv` setup from a project:
+If you would like to remove the `renv` set-up from a project:
 
-- run `renv::deactivate()` to fall back on a `renv`-free setup;
+- run `renv::deactivate()` to fall back on a `renv`-free set-up;
 - delete `renv.lock` and the `renv` folder for clarity.

--- a/renv.Rmd
+++ b/renv.Rmd
@@ -35,7 +35,7 @@ This ensures that the dependencies of the projects, listed in the `DESCRIPTION` 
 The `renv` initialization causes:
 
 - the creation of the lock-file `renv.lock`, which tracks the version of the resolved transitive package dependencies, along with the R version and package repositories information;
-- the set-up of `renv` infrastructure for the project including a specific library;
+- the set-up of `renv` infrastructure for the project including a specific library, where packages are installed at the versions tracked in `renv.lock`;
 - the creation of a new `renv` folder containing:
     - a settings file `settings.json`,
     - a script `activate.R` to activate the project-specific virtual environment;

--- a/renv.Rmd
+++ b/renv.Rmd
@@ -35,7 +35,7 @@ renv::init(
 This ensures that the dependencies of the package, as listed in the `DESCRIPTION` file are used for initializing the virtual environment. 
 
 Note: with `snapshot.type = "explicit"` `renv` tracks and installs only the packages *explicitly* mentioned in the `DESCRIPTION` file. This means that only the dependencies used by the package are installed. Packages needed for development, such as `devtools`, should be be installed for the specific project via `install.packages()` or `renv::install()`.   
-`snapshot.type = "explicit"`,  (the default), uses all packages captured by `renv::dependencies()`.
+`snapshot.type = "implicit"`, (the default), uses all packages captured by `renv::dependencies()`.
 
 The `renv` initialization causes:
 

--- a/renv.Rmd
+++ b/renv.Rmd
@@ -27,7 +27,7 @@ In order resolve and track dependencies of a project, `renv` needs to discover w
 To initialize `renv` for a project where dependencies are explicitly stated in the `DESCRIPTION` file, run:
 
 ```{r, echo = TRUE, eval = FALSE}
-renv::init(settings = list(snapshot.type = "implicit"))
+renv::init(settings = list(snapshot.type = "explicit"))
 ```
 
 This ensures that the dependencies of the projects, listed in the `DESCRIPTION` file, are considered for initializing the virtual environment.

--- a/renv.Rmd
+++ b/renv.Rmd
@@ -3,122 +3,117 @@
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE, collapse = TRUE, eval = FALSE)
 ```
-For production readiness - and project safety - it is important to control the dependencies of a piece of development. This can be done at project level using the package [`renv`](https://rstudio.github.io/renv/).
 
-In a `renv`-project (and a new R session starts), `renv` detects the project dependencies and whether they are out of sync, ensuring the same virtual environment applies all the time the project is opened.
+For production readiness --- and project safety --- it is important to control the dependencies of a piece of development. This can be done at project level using the package [`renv`](https://rstudio.github.io/renv/).
 
-This approach ensures that the set of dependencies is collaboratively shared and maintained. Moreover, it can be used to align the development environment to the production stage. Managing the dependencies the way up to production improves reproducibility, a key requirement in enterprise.
+In an `renv` project, dependencies are resolved and tracked in a lock-file. As a new R session starts, `renv` detects whether installed dependencies are out of sync compared to the lock-file, ensuring the same virtual environment applies each time the project is opened.
 
-Finally, as the control is at project level, it is possible to have different virtual environments (for example different packages version) for different projects, while keeping the maintenance of the versioned package library efficient through caching.
+This approach ensures that the set of dependencies is collaboratively shared and maintained. Moreover, it can be used to align the development environment to the production stage. Managing and controlling dependencies all the way up from development to production improves reproducibility and empowers automated deployments, a key requirement in enterprise.
+
+Finally, as the control is at project level, it is possible to have different virtual environments (with different packages version) for different projects, while keeping the maintenance of the versioned package library efficient through caching.
 
 ## Install `renv`
 
 `renv` can be installed from CRAN as:
 
-```{r, echo =  TRUE , eval = FALSE}
+```{r, echo = TRUE, eval = FALSE}
 install.packages("renv")
 ```
 
-## Initialize an `renv` project
+## Set-up an `renv` project
 
-To initialize a package with `renv`, run:
+In order resolve and track dependencies of a project, `renv` needs to discover what the required packages are. Although `renv` supports discovering dependencies by scanning all files in the project (_implicit mode_), we strongly advise to define the required dependencies in a `DESCRIPTION` file, and rely on `renv`'s _explicit mode_ (see ['Snapshot types'](https://rstudio.github.io/renv/reference/snapshot.html#snapshot-types) in the documentation for details).
 
-```{r , echo = TRUE, eval = FALSE}
-renv::init(
-  # use the DESCRIPTION file to capture dependencies
-  settings = list(snapshot.type = "explicit"),
-  # do not install dependencies (done in a custom way)
-  bare = TRUE
-)
+To initialize `renv` for a project where dependencies are explicitly stated in the `DESCRIPTION` file, run:
+
+```{r, echo = TRUE, eval = FALSE}
+renv::init(settings = list(snapshot.type = "implicit"))
 ```
 
-This ensures that the dependencies of the package, as listed in the `DESCRIPTION` file are used for initializing the virtual environment. 
-
-Note: with `snapshot.type = "explicit"` `renv` tracks and installs only the packages *explicitly* mentioned in the `DESCRIPTION` file. This means that only the dependencies used by the package are installed. Packages needed for development, such as `devtools`, should be be installed for the specific project via `install.packages()` or `renv::install()`.   
-`snapshot.type = "implicit"`, (the default), uses all packages captured by `renv::dependencies()`.
+This ensures that the dependencies of the projects, listed in the `DESCRIPTION` file, are considered for initializing the virtual environment.
 
 The `renv` initialization causes:
 
-- the creation of a new `renv.lock` file where the R version and the list of used packages with their version are tracked (if `bare = FALSE`);
-- the set-up of project infrastructure including the project library;
-- the execution of the activation script on project launch via `.Rprofile` that ensures renv will be used in all future sessions;
+- the creation of the lock-file `renv.lock`, which tracks the version of the resolved transitive package dependencies, along with the R version and package repositories information;
+- the set-up of `renv` infrastructure for the project including a specific library;
 - the creation of a new `renv` folder containing:
-    - a setting file `settings.jsn`,
+    - a settings file `settings.json`,
     - a script `activate.R` to activate the project-specific virtual environment;
+- the inclusion of the activation script in `.Rprofile`, which ensures activation upon session start in the project;
 - an update of the `.Rbuildignore` because the `renv`-specific files are not part of the R package infrastructure;
-- an update of the `.gitignore` to exclude the `renv` library from version control, as it can be simply restored via `renv::restore()`.
 
-Having all the `renv` infrastructure committed under version control ensures that the same `renv` set-up is available to anyone working on the same project (via `renv::restore()`).
+Note that, by default, `renv` will use the repository from **Posit Public Package Manager** (_PPM_) CRAN mirror for package installation. 
 
-By default `renv` will use the repository from **Posit Public Package Manager** (*PPM*) CRAN mirror for package installation. 
+Having all the `renv` infrastructure committed under version control ensures that the same `renv` set-up and environment is available to anyone working on the same project.
 
-### Control packages version
-
-As a note, if the `DESCRIPTION` file does not request a specific package version, the `renv` initialization will pick the version currently available in the user library when the snapshot of the packages was created. However, it is advisable to have a stricter control over the version of the packages used in a project. To do so, one can set the option to install dependencies from a specific *PPM* repo, therefore fixing the version for all available packages.
-
-```{r , echo = TRUE, eval = FALSE}
-# Install all dependencies from a specific PPM date repo
-options(repos = "https://packagemanager.rstudio.com/cran/2023-01-02")
-```
-
-One can then install the dependencies of a package via:
-
-```{r , echo = TRUE, eval = FALSE}
-renv::install("remotes")
-(deps <- remotes::dev_package_deps(dependencies = TRUE))
-renv::install(with(deps, sprintf("%s@%s", package[diff!=0], available[diff!=0])))
-```
-
-To create a snapshot of the package dependencies and update the `renv.lock` file:
-
-```{r , echo = TRUE, eval = FALSE}
-# Create a snapshot to track dependencies in the lockfile
-renv::snapshot()
-```
-To include development dependencies, i.e. listed in `Suggests` of the `DESCRIPTION` file:
-
-```{r , echo = TRUE, eval = FALSE}
-# Create a snapshot to track all dependencies, including Suggested, in the lockfile
-renv::snapshot(dev = TRUE)
-```
-
-Similarly to fixing the date of a snapshot repo, we can also **check out** and retrieve the latest-available packages from a snapshot.
-```{r , echo = TRUE, eval = FALSE}
-# check out packages from PPM using the date '2023-01-02'
-renv::checkout(date = "2023-01-02")
-# or
-renv::checkout(repos = "https://packagemanager.rstudio.com/cran/2023-01-02")
-# see "actions" argument for different snapshot behaviours.
-```
-
-The same can be done for a single package.
-```{r , echo = TRUE, eval = FALSE}
-# only check out a subset of packages (and their recursive dependencies)
-renv::checkout(packages = "dplyr", date = "2023-01-02")
-```
-
-## Caching the packages' versions
-
-`renv` caches the packages' versions. If you have installed the same package version in a different project, you should have it already cached and available.   
-By running:
+Upon session startup, `renv` would detect mismatches between the package versions recorded in `renv.lock` and those installed in the project library, hinting at actions to ensure consistency. In particular,
 
 ```{r, echo =  TRUE , eval = FALSE}
 renv::status()
 ```
 
-one can check if packages versions are out of sync, and follow the indications in the "Missing packages" of `?renv::status` if mismatches are found.
+would check and provide information about packages whose version is out-of-sync, whereas
 
-Instead, via 
 
 ```{r, echo =  TRUE , eval = FALSE}
 renv::restore()
 ```
 
-it is possible to restore the versions as listed in the `renv.lock` file.
+would restore the versions as listed in `renv.lock`, and is the go-to command to ensure the local environment is always aligned with the locked dependencies.
+
+### Development dependencies
+
+By default, development dependencies (like those specified under `Suggests:` in the `DESCRIPTION` file), are not included in `renv.lock`. They can be however included via
+
+```{r, echo = TRUE, eval = FALSE}
+renv::snaphot(dev = TRUE)
+```
+
+Note that, given the default behavior with respect to development dependencies, `renv` might report out-of-sync dependencies upon session startup. Make sure to use
+
+```{r, echo = TRUE, eval = FALSE}
+renv::status(dev = TRUE)
+```
+
+if you are included development dependencies in `renv.lock`.
+
+Given that only packages _explicitly_ mentioned in the `DESCRIPTION` file are taken care of by `renv`, additional packages used for development, such as `devtools` or `usethis`, should be installed for the specific project via `install.packages()` or `renv::install()`, and are never included in the lock-file.
+
+### Control package versions
+
+If the `DESCRIPTION` file does not request a specific package version, `renv` will use the latest version in the repository, which is always the case for indirect/transitive dependencies. Although the locking mechanism allows to freeze such versions, it might be desirable to have a stricter control over the versions of packages used in a project. To do so, one can leverage the **date-based CRAN snapshots** provided by PPM, e.g.
+
+```{r , echo = TRUE, eval = FALSE}
+# Install all dependencies from a specific CRAN snapshot date on PPM
+options(repos = "https://packagemanager.posit.co/cran/2024-01-02")
+```
+
+Date-based CRAN snapshots have built-in support in `renv` with [`renv::checkout()`](https://rstudio.github.io/renv/reference/checkout.html), w/o the need for `(options(repos = ...))`:
+
+```{r , echo = TRUE, eval = FALSE}
+# check out packages from PPM using the date '2023-01-02'
+renv::checkout(date = "2024-01-02")
+# or provide the repos URL explicitly
+renv::checkout(repos = "https://packagemanager.posit.co/cran/2024-01-02")
+```
+
+By default, `renv::checkout()` would ensure packages in the project library are installed from the specific date, w/o updating `renv.lock`. This implies you will have to run `renv::snapshot()` to updated the lock-file. As an alternative, you could use the `actions` argument to control the behavior of `renv::checkout()`. In particular,
+
+```{r , echo = TRUE, eval = FALSE}
+renv::checkout(date = "2023-01-02", actions=c("snapshot", "restore"))
+```
+
+would install packages and lock the corresponding versions (as well as the used repository) at the same time.
+
+Note that `renv::checkout()` can also be use for a subset of packages (and their transitive  dependencies)
+
+```{r , echo = TRUE, eval = FALSE}
+renv::checkout(packages = "dplyr", date = "2024-01-02")
+```
 
 ## Removing the `renv` setup from a project
 
 If you would like to remove the `renv` set-up from a project:
 
-- run `renv::deactivate()` to fall back on a `renv`-free set-up;
-- delete `renv.lock` and the `renv` folder for clarity.
+- run `renv::deactivate()` to fall back on an `renv`-free set-up;
+- delete `renv.lock` and the `renv` folder.

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -59,14 +59,20 @@ If your project relies on package [renv](https://rstudio.github.io/renv/) for tr
 
 #### Deployment
 
-- Continuous deployment to shinyapps.io is automated upon any push to the `main` (or `master`) branch.
-  - In order to provide credentials for the deployment, account name and corresponding [tokens](https://docs.posit.co/shinyapps.io/getting-started.html#deploying-applications) for shinyapps.io are defined as environment variables `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN` and `SHINYAPPS_SECRET`, specified / accessible as GitHub [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
-  - A convenience R script, e.g. `deploy/deploy-shinyapps.R` (build-ignored via `usethis::use_build_ignore("deploy")`), defines the deployment commands based on the environment variables.
-```{r read-deploy-script, eval = TRUE, echo = FALSE}
-knitr::read_chunk("shiny-ci-cd/deploy/deploy-shinyapps.R", labels = "deploy-shinyapps")
-```
-```{r deploy-shinyapps}
-```
+Continuous deployment to shinyapps.io is automated upon any push to the `main` (or `master`) branch.
+
+- In order to provide credentials for the deployment, account name and corresponding [tokens](https://docs.posit.co/shinyapps.io/getting-started.html#deploying-applications) for shinyapps.io are defined as environment variables `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN` and `SHINYAPPS_SECRET`, specified / accessible as GitHub Actions [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+- Deployment to shinyapps.io is best configured and defined in an R script, e.g.  `deploy/deploy-shinyapps.R` (build-ignored via `usethis::use_build_ignore("deploy")`), which:
+  - sets up account credentials based on the environment variables for continuous deployment
+  - deploys the app via `rsconnect::deployApp()`, specifying as files for deployment only what is relevant at run-time: this does not only prevent unnecessary files from being deployed, but also makes sure only run-time dependencies are captured in the deployment
+
+  The script would also be used locally for manual deployments (to rely on the defined files), where credentials would be manually configured.
+
+  ```{r read-deploy-script, eval = TRUE, echo = FALSE}
+  knitr::read_chunk("shiny-ci-cd/deploy/deploy-shinyapps.R", labels = "deploy-shinyapps")
+  ```
+  ```{r deploy-shinyapps}
+  ```
 
 ### Workflow file
 

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -59,7 +59,7 @@ If your project relies on package [renv](https://rstudio.github.io/renv/) for tr
 
 #### Deployment
 
-- Continuous deployment to shinyapps.io is automated upon any push to the `master` branch
+- Continuous deployment to shinyapps.io is automated upon any push to the `main` (or `master`) branch.
   - In order to provide credentials for the deployment, account name and corresponding [tokens](https://docs.rstudio.com/shinyapps.io/getting-started.html#deploying-applications) for shinyapps.io are defined as environment variables `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN` and `SHINYAPPS_SECRET`, specified / accessible as GitHub [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
   - A convenience R script, e.g. `deploy/deploy-shinyapps.R` (build-ignored via `usethis::use_build_ignore("deploy")`), defines the deployment commands based on the environment variables.
 ```{r read-deploy-script, eval = TRUE, echo = FALSE}

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -53,6 +53,14 @@ If your project relies on package [renv](https://rstudio.github.io/renv/) for tr
 - system requirements are installed explicitly (for the `ubuntu` runner defined for the workflow), based on `pkgdepends`.
 - dependencies tracked by renv are installed (including caching) using [`r-lib/actions/setup-renv`](https://github.com/r-lib/actions/tree/v2/setup-renv#readme).
 
+Some remarks about using an `renv` setup for a packaged Shiny app and a corresponding CI/CD workflow (see also our chapter ['Control dependencies with `renv`'](control-dependencies-with-renv.html) for details):
+
+- `renv` should be configured using `"explicit"` snapshots, given that dependencies are stated in the `DESCRIPTION` file.
+- As the `DESCRIPTION` file defines the development dependencies used for CI/CD, make sure they are tracked by `renv` via `renv::snapshot(dev = TRUE)` so they are restored and available in the workflow.
+- Since the deployment to shinyapps.io is also based on `renv` and would rely on an existing `renv.lock`, we would end up with development dependencies included in the deployment.
+  - To prevent this, we can ignore `renv.lock` during development by creating an `.rscignore` text file containing `renv.lock` in the project root (build-ignored via `usethis::use_build_ignore(".rscignore")`).
+  - This will cause `rsconnect::deployApp()` to create a new `renv` snapshot with the run-time dependencies only, still relying on the versions restored from `renv.lock` in the workflow via `r-lib/actions/setup-renv`.
+
 #### Package check
 
 - Check the package using [`r-lib/actions/check-r-package`](https://github.com/r-lib/actions/tree/v2/check-r-package#readme).

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -43,15 +43,15 @@ A workflow should have an identifying `name` and an `on` section that indicates 
 #### Setup
 
 - Checkout the source package from the repository, using `actions/checkout` provided by GitHub.
-- Setup R using the action [`r-lib/actions/setup-r`](https://github.com/r-lib/actions/tree/master/setup-r#readme).
-- Install package dependencies (including system requirements and caching) using [`r-lib/actions/setup-r-dependencies`](https://github.com/r-lib/actions/tree/master/setup-r-dependencies#readme).
+- Setup R using the action [`r-lib/actions/setup-r`](https://github.com/r-lib/actions/tree/v2/setup-r#readme).
+- Install package dependencies (including system requirements and caching) using [`r-lib/actions/setup-r-dependencies`](https://github.com/r-lib/actions/tree/v2/setup-r-dependencies#readme).
 
 ##### Using renv {-}
 
 If your project relies on package [renv](https://rstudio.github.io/renv/) for tracking dependencies via an `renv.lock` file, caching and installation of R package dependencies requires a different setup, as described in the [Using renv with Continuous Integration](https://rstudio.github.io/renv//articles/ci.html#github-actions) vignette. As shown in the complete workflow files [below](#complete-wfs-use-gh-action):
 
 - system requirements are installed explicitly (for the `ubuntu` runner defined for the workflow) based on `remotes::system_requirements()`
-- dependencies tracked by renv are installed (including caching) using [`r-lib/actions/setup-renv`](https://github.com/r-lib/actions/tree/master/setup-renv#readme)
+- dependencies tracked by renv are installed (including caching) using [`r-lib/actions/setup-renv`](https://github.com/r-lib/actions/tree/v2/setup-renv#readme).
 
 #### Package check
 

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -50,7 +50,7 @@ A workflow should have an identifying `name` and an `on` section that indicates 
 
 If your project relies on package [renv](https://rstudio.github.io/renv/) for tracking dependencies via an `renv.lock` file, caching and installation of R package dependencies requires a different setup, as described in the [Using renv with Continuous Integration](https://rstudio.github.io/renv//articles/ci.html#github-actions) vignette. As shown in the complete workflow files [below](#complete-wfs-use-gh-action):
 
-- system requirements are installed explicitly (for the `ubuntu` runner defined for the workflow) based on `remotes::system_requirements()`
+- system requirements are installed explicitly (for the `ubuntu` runner defined for the workflow), based on `pkgdepends`.
 - dependencies tracked by renv are installed (including caching) using [`r-lib/actions/setup-renv`](https://github.com/r-lib/actions/tree/v2/setup-renv#readme).
 
 #### Package check

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -107,7 +107,7 @@ usethis::use_github_action(url = paste0(
   # "shiny-ci-cd/actions/ci.yml"
   # "shiny-ci-cd/actions/ci-renv.yml"
 ))
-usethis::use_github_actions_badge("CI-CD") # or "CI"
+usethis::use_github_actions_badge("ci-cd.yml") # or "ci.yml"/"ci(-cd)-renv.yml"
 ```
 
 #### Complete workflow files

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -60,7 +60,7 @@ If your project relies on package [renv](https://rstudio.github.io/renv/) for tr
 #### Deployment
 
 - Continuous deployment to shinyapps.io is automated upon any push to the `main` (or `master`) branch.
-  - In order to provide credentials for the deployment, account name and corresponding [tokens](https://docs.rstudio.com/shinyapps.io/getting-started.html#deploying-applications) for shinyapps.io are defined as environment variables `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN` and `SHINYAPPS_SECRET`, specified / accessible as GitHub [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+  - In order to provide credentials for the deployment, account name and corresponding [tokens](https://docs.posit.co/shinyapps.io/getting-started.html#deploying-applications) for shinyapps.io are defined as environment variables `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN` and `SHINYAPPS_SECRET`, specified / accessible as GitHub [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
   - A convenience R script, e.g. `deploy/deploy-shinyapps.R` (build-ignored via `usethis::use_build_ignore("deploy")`), defines the deployment commands based on the environment variables.
 ```{r read-deploy-script, eval = TRUE, echo = FALSE}
 knitr::read_chunk("shiny-ci-cd/deploy/deploy-shinyapps.R", labels = "deploy-shinyapps")
@@ -193,7 +193,7 @@ deploy:
     branch: master
 ```
 
-where `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN`, `SHINYAPPS_SECRET` are [secure variables defined on Travis CI](https://docs.travis-ci.com/user/environment-variables/) holding your account name and corresponding  [tokens](https://docs.rstudio.com/shinyapps.io/getting-started.html#deploying-applications) for shinyapps.io.
+where `SHINYAPPS_ACCOUNT`, `SHINYAPPS_TOKEN`, `SHINYAPPS_SECRET` are [secure variables defined on Travis CI](https://docs.travis-ci.com/user/environment-variables/) holding your account name and corresponding  [tokens](https://docs.posit.co/shinyapps.io/getting-started.html#deploying-applications) for shinyapps.io.
 
 It is in fact more convenient to write an R script, saved as e.g. `deploy/deploy-shinyapps.R` (build-ignored via `usethis::use_build_ignore("deploy")`) defining the deployment commands:
 ```{r deploy-shinyapps}

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -55,7 +55,7 @@ If your project relies on package [renv](https://rstudio.github.io/renv/) for tr
 
 #### Package check
 
-- Check the package via `rcmdcheck::rcmdcheck()`.
+- Check the package using [`r-lib/actions/check-r-package`](https://github.com/r-lib/actions/tree/v2/check-r-package#readme).
 
 #### Deployment
 

--- a/shiny-ci-cd.Rmd
+++ b/shiny-ci-cd.Rmd
@@ -15,34 +15,30 @@ The development of a packaged Shiny app under version control can easily enable 
 
 This guide illustrates how to set up CI/CD pipelines with a focus on the increasingly popular [GitHub Actions](https://github.com/features/actions), which we recommend as a natural choice for GitHub open source projects. In particular, it shows how a Shiny app developed as an R package can be maintained on a GitHub repository, be deployed to and hosted on [shinyapps.io](https://www.shinyapps.io) using said CI/CD pipelines. For the sake of completeness, and for historical reasons, the guide also covers the CI/CD setup on [Travis CI](https://www.travis-ci.com), a well established service that has become not attractive any longer for open source projects due to its change of policy in recent years.
 
-[ShinyCICD](https://github.com/miraisolutions/ShinyCICD) is a minimal example of a packaged Shiny app that will be used as an example throughout the guide. You can simply [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository and setup your specific user settings (especially for shinyapps.io) to see CI/CD pipelines in actions, or follow the steps described below to setup CI/CD pipelines for your own app.
+[ShinyCICD](https://github.com/miraisolutions/ShinyCICD) is a minimal example of a packaged Shiny app that will be used as an example throughout the guide. You can simply [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository and setup your specific user settings (especially for shinyapps.io) to see CI/CD pipelines in actions, or follow the steps described in this chapter to setup CI/CD pipelines for your own app.
 
 ## Generic CI/CD pipeline
 
 Generally speaking, a CI/CD pipeline related to an R package is comprised of the following steps:
 
 - setup a running environment
+- check out the source code
 - setup R
-- check out the package source code
-- install system dependencies
-- install package dependencies (with caching)
-- build the package
-- check the package
+- install package dependencies (with caching), including their system requirements
+- build and check the package
 - deploy
 
 GitHub Actions provides great flexibility in specifying and customizing each individual step, but many are covered by the R-specific actions provided by the [r-lib/actions](https://github.com/r-lib/actions#readme) project. Most of these steps are implemented by default in Travis CI for an R package.
 
 ## GitHub Actions
 
-[GitHub Actions](https://docs.github.com/en/actions) is a service for running highly-customizable and flexible automated workflows, fully integrated with GitHub and very suitable to CI/CD pipelines.
-[Workflows](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions) use `YAML` syntax and should be stored in the `.github/workflows` directory in the root of the repository.
-Workflows are constituted of jobs and each job is a set of steps to perform individual tasks, e.g. commands or actions.
+[GitHub Actions](https://docs.github.com/en/actions) is a service for running highly-customizable and flexible automated workflows, fully integrated with GitHub and very suitable to CI/CD pipelines. [Workflows](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions) use `YAML` syntax and should be stored in the `.github/workflows` directory in the root of the repository. Workflows are constituted of jobs and each job is a set of steps to perform individual tasks, e.g. commands or actions.
 
-The next sections describe in detail the relevant workflow steps of a typical CI/CD pipeline for a packages Shiny app, also covering the usage of `renv` to track package dependencies. Finally, we will show how you can use the convenience function `usethis::use_github_action()` for including such workflows in you project.
+The next sections describe in detail the relevant workflow steps of a typical CI/CD pipeline for a packaged Shiny app, also covering the usage of `renv` to track package dependencies. Finally, we will show how you can use the convenience function `usethis::use_github_action()` for including such workflows in you project.
 
 ### Workflow steps
 
-A workflow should have an identifying `name` and an `on` section that indicates upon which events the workflow should be triggered. It should include at least one job and each job will have a set of steps fully specifying what to execute. Such steps can be an action (predefined, sourcing from GitHub repos that contain such actions) or custom shell commands. With the introduction of [composite Actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action), most of the relevant workflow steps for an R project are covered by actions provided by the [r-lib/actions](https://github.com/r-lib/actions#readme).
+A workflow should have an identifying `name` and an `on` section that indicates upon which events the workflow should be triggered. It should include at least one job and each job will have a set of steps fully specifying what to execute. Such steps can be an action (predefined, sourcing from GitHub repos that contain such actions) or custom shell commands. With the introduction of [composite Actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action), most of the relevant workflow steps for an R project are covered by actions provided by the [r-lib/actions](https://github.com/r-lib/actions#readme) repository.
 
 #### Setup
 

--- a/shiny-ci-cd/actions/ci-cd-renv.yml
+++ b/shiny-ci-cd/actions/ci-cd-renv.yml
@@ -33,24 +33,27 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          # Enable RStudio Package Manager to speed up package installation
-          use-public-rspm: true
+          # No RStudio Package Manager to respect renv.lock
+          use-public-rspm: false
 
       - name: Install system dependencies
         # This is not taken care of (yet) by r-lib/actions/setup-renv
-        # Package distro used to get the distro for the used ubuntu-latest
+        # See https://github.com/r-lib/actions/issues/785
         run: |
-          Rscript -e "install.packages(c('remotes', 'distro'))"
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(with(distro::distro(), remotes::system_requirements(id, short_version)))')
+          # We rely on pkgdepends from the library embedded in pak
+          install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")
+          install.packages("jsonlite")
+          .libPaths(c(system.file("library", package = "pak"), .libPaths()))
+          pkgdepends::new_pkg_installation_proposal(
+            names(jsonlite::read_json("renv.lock")$Packages), config = list(dependencies = FALSE)
+          )$solve()$install_sysreqs()
+        shell: Rscript {0}
 
       - name: Activate renv and restore packages with cache
         uses: r-lib/actions/setup-renv@v2

--- a/shiny-ci-cd/actions/ci-cd-renv.yml
+++ b/shiny-ci-cd/actions/ci-cd-renv.yml
@@ -22,7 +22,7 @@ jobs:
       # single OS and R version, aligned with the target deployment environment
       matrix:
         config:
-          - {os: ubuntu-latest, r: 'release'}
+          - {os: ubuntu-latest, r: 'renv'}
 
     env:
       # Access token for GitHub

--- a/shiny-ci-cd/actions/ci-cd-renv.yml
+++ b/shiny-ci-cd/actions/ci-cd-renv.yml
@@ -1,8 +1,9 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 
-# Name of the workflow => usethis::use_github_actions_badge("CI-CD-renv")
+# Name of the workflow
 name: CI-CD-renv
+# Create status badge with usethis::use_github_actions_badge("ci-cd-renv.yml")
 
 on:
   # Triggered on push and pull request events

--- a/shiny-ci-cd/actions/ci-cd.yml
+++ b/shiny-ci-cd/actions/ci-cd.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2

--- a/shiny-ci-cd/actions/ci-cd.yml
+++ b/shiny-ci-cd/actions/ci-cd.yml
@@ -1,8 +1,9 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 
-# Name of the workflow => usethis::use_github_actions_badge("CI-CD")
+# Name of the workflow
 name: CI-CD
+# Create status badge with usethis::use_github_actions_badge("ci-cd.yml")
 
 on:
   # Triggered on push and pull request events
@@ -29,6 +30,9 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # Preserve package sources for informative references in case of errors
       R_KEEP_PKG_SOURCE: yes
+      # rsconnect needs transitive LinkingTo-only dependencies to be installed
+      # (see https://github.com/r-lib/pak/issues/485)
+      PKG_INCLUDE_LINKINGTO: true
 
     steps:
 

--- a/shiny-ci-cd/actions/ci-renv.yml
+++ b/shiny-ci-cd/actions/ci-renv.yml
@@ -33,24 +33,27 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          # Enable RStudio Package Manager to speed up package installation
-          use-public-rspm: true
+          # No RStudio Package Manager to respect renv.lock
+          use-public-rspm: false
 
       - name: Install system dependencies
         # This is not taken care of (yet) by r-lib/actions/setup-renv
-        # Package distro used to get the distro for the used ubuntu-latest
+        # See https://github.com/r-lib/actions/issues/785
         run: |
-          Rscript -e "install.packages(c('remotes', 'distro'))"
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(with(distro::distro(), remotes::system_requirements(id, short_version)))')
+          # We rely on pkgdepends from the library embedded in pak
+          install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")
+          install.packages("jsonlite")
+          .libPaths(c(system.file("library", package = "pak"), .libPaths()))
+          pkgdepends::new_pkg_installation_proposal(
+            names(jsonlite::read_json("renv.lock")$Packages), config = list(dependencies = FALSE)
+          )$solve()$install_sysreqs()
+        shell: Rscript {0}
 
       - name: Activate renv and restore packages with cache
         uses: r-lib/actions/setup-renv@v2

--- a/shiny-ci-cd/actions/ci-renv.yml
+++ b/shiny-ci-cd/actions/ci-renv.yml
@@ -22,7 +22,7 @@ jobs:
       # single OS and R version, aligned with the target deployment environment
       matrix:
         config:
-          - {os: ubuntu-latest, r: 'release'}
+          - {os: ubuntu-latest, r: 'renv'}
 
     env:
       # Access token for GitHub

--- a/shiny-ci-cd/actions/ci-renv.yml
+++ b/shiny-ci-cd/actions/ci-renv.yml
@@ -1,8 +1,9 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 
-# Name of the workflow => usethis::use_github_actions_badge("CI-renv")
+# Name of the workflow
 name: CI-renv
+# Create status badge with usethis::use_github_actions_badge("ci-renv.yml")
 
 on:
   # Triggered on push and pull request events

--- a/shiny-ci-cd/actions/ci.yml
+++ b/shiny-ci-cd/actions/ci.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2

--- a/shiny-ci-cd/actions/ci.yml
+++ b/shiny-ci-cd/actions/ci.yml
@@ -1,8 +1,9 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 
-# Name of the workflow => usethis::use_github_actions_badge("CI")
+# Name of the workflow
 name: CI
+# Create status badge with usethis::use_github_actions_badge("ci.yml")
 
 on:
   # Triggered on push and pull request events
@@ -29,6 +30,9 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       # Preserve package sources for informative references in case of errors
       R_KEEP_PKG_SOURCE: yes
+      # rsconnect needs transitive LinkingTo-only dependencies to be installed
+      # (see https://github.com/r-lib/pak/issues/485)
+      PKG_INCLUDE_LINKINGTO: true
 
     steps:
 

--- a/shiny-ci-cd/deploy/deploy-shinyapps.R
+++ b/shiny-ci-cd/deploy/deploy-shinyapps.R
@@ -5,5 +5,13 @@ rsconnect::setAccountInfo(
   Sys.getenv("SHINYAPPS_TOKEN"),
   Sys.getenv("SHINYAPPS_SECRET")
 )
-rsconnect::deployApp(appName = "ShinyCICD",
+# Add here any additional files/directories the app needs
+app_files = c(
+  "app.R",
+  "DESCRIPTION",
+  "NAMESPACE",
+  "R/",
+  "inst/"
+)
+rsconnect::deployApp(appName = "ShinyCICD", appFiles = app_files,
                      forceUpdate = TRUE)

--- a/shiny-ci-cd/deploy/deploy-shinyapps.R
+++ b/shiny-ci-cd/deploy/deploy-shinyapps.R
@@ -1,10 +1,12 @@
 # deploy/deploy-shinyapps.R
 # usethis::use_build_ignore("deploy")
-rsconnect::setAccountInfo(
-  Sys.getenv("SHINYAPPS_ACCOUNT"),
-  Sys.getenv("SHINYAPPS_TOKEN"),
-  Sys.getenv("SHINYAPPS_SECRET")
-)
+if (!interactive()) {
+  rsconnect::setAccountInfo(
+    Sys.getenv("SHINYAPPS_ACCOUNT"),
+    Sys.getenv("SHINYAPPS_TOKEN"),
+    Sys.getenv("SHINYAPPS_SECRET")
+  )
+}
 # Add here any additional files/directories the app needs
 app_files = c(
   "app.R",
@@ -13,5 +15,6 @@ app_files = c(
   "R/",
   "inst/"
 )
-rsconnect::deployApp(appName = "ShinyCICD", appFiles = app_files,
-                     forceUpdate = TRUE)
+rsconnect::deployApp(
+  appName = "ShinyCICD", appFiles = app_files, forceUpdate = TRUE
+)

--- a/shiny-ci-cd/deploy/deploy-shinyapps.R
+++ b/shiny-ci-cd/deploy/deploy-shinyapps.R
@@ -5,4 +5,5 @@ rsconnect::setAccountInfo(
   Sys.getenv("SHINYAPPS_TOKEN"),
   Sys.getenv("SHINYAPPS_SECRET")
 )
-rsconnect::deployApp(appName = "ShinyCICD")
+rsconnect::deployApp(appName = "ShinyCICD",
+                     forceUpdate = TRUE)


### PR DESCRIPTION
Update of renv chapter. See also #41 

- added a phrase about `snapshot.type = "explicit" / "implicit"`
- updated what is generated in the "renv" folder
- Mentioned in an additional sentence the PPM repo
- `options(repos = "https://packagemanager.rstudio.com/cran/2023-01-02")` works to fix the date of the repo, like MRAN was working previously. tested.
- added a second sentence about `renv::snapshot(dev = TRUE)`
- rephrased/improved "Caching the packages' versions", adding new insight from the help file of `renv::status`
- Added few lines and examples about `renv::checkout()`

I have tested the usage of `renv::checkout(date = , repos = )` and `options(repo = )`. Also checkout is then setting the new repo to the date specified (or to the repos url). 
I.e. `renv::checkout(date = "2023-01-01" )` would then set also  `options(repos = "https://packagemanager.rstudio.com/cran/2023-01-01")`.

Checkout has more options, packages can be installed, or only a snapshot of the `renv.lock` can be done.

Update of CI-CD chapter.

- updated workflows yml to mirror ShinyCICD repo
- added `forceUpdate = TRUE` to `rsconnect::deployApp` 




